### PR TITLE
Add Regex for Combat Skills

### DIFF
--- a/KR/ManualTranslations.txt
+++ b/KR/ManualTranslations.txt
@@ -1540,6 +1540,8 @@ S레벨 팬 카드=Level S Fan Card
 어렴풋이 전기의 단장을 엿볼 수 있다. 괴도 경험치를 높이는 데 사용된다. 사용 시 즉시 1,000포인트가 증가한다.=A brief glimpse into an epic tale. Instantly grants 1,000 Phantom Thief EXP when used.
 어렴풋이 전기의 전서를 엿볼 수 있다. 괴도 경험치를 높이는 데 사용된다. 사용 시 즉시 4,000포인트가 증가한다.=A full glimpse into an epic tale. Instantly grants 4,000 Phantom Thief EXP when used.
 #####Combat Skills
+sr:"(.*?) Lv.(\d+)"=$1 Lv.$2
+sr:"(.*?) <color\=#0F69CB>Lv.(\d+)</color>"=$1 <color\=#0F69CB>Lv.$2</color>
 전투 기술=Combat Skills
 전투 기술 Lv.1=Combat Skills Lv.1
 전투 기술 Lv.2=Combat Skills Lv.2


### PR DESCRIPTION
This addition should allow for the removal of the Lv.1 - 5 strings for skills, making only the base skill name necessary, but I don't own all of the characters to make sure it wouldn't break things